### PR TITLE
remove bottle :unneeded

### DIFF
--- a/Formula/git-profile.rb
+++ b/Formula/git-profile.rb
@@ -3,7 +3,6 @@ class GitProfile < Formula
   desc "Allows switch between multiple user profiles in git repositories"
   homepage "https://github.com/dotzero/git-profile"
   version "1.3.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/dotzero/git-profile/releases/download/v1.3.2/git-profile_1.3.2_macos_x86_64.tar.gz"


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the dotzero/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/dotzero/homebrew-tap/Formula/git-profile.rb:6
```